### PR TITLE
fix: robustify pybullet simulation's contact check

### DIFF
--- a/scripts/pybullet_simulation.py
+++ b/scripts/pybullet_simulation.py
@@ -145,7 +145,12 @@ class PyBulletSim:
     def get_state(self):
         state = ModelState()
 
-        contact = len(p.getContactPoints(bodyA=self.robot_id, bodyB=self.lower_ball_id)) > 0
+        # Note: one would expect that only checking getContactPoints would suffice here;
+        # However, there are cases where getContactPoints(...) returns no points,
+        # but getClosestPoints(..., distance=0) does.
+        contact = p.getContactPoints(bodyA=self.robot_id, bodyB=self.lower_ball_id) \
+            or p.getClosestPoints(bodyA=self.robot_id, bodyB=self.lower_ball_id, distance=0)
+
         if not contact:
             return state
 


### PR DESCRIPTION
In the `python3 scripts/pybullet_interactive_demo.py`, sometimes the `getContactPoints` would return no points even though the distance between the balls is less then the sum of their radii, which currently causes the robot to abruptly stop the motors and the camera to pan to the default view. Checking `getClosestPoints` instead / in addition avoids this issue.